### PR TITLE
Add Creation, Cancellation, and Validation Logic for Payment Entry Linked to Sales App Payment Entry

### DIFF
--- a/sales_app/eactive_sales_app/doctype/sales_app_payment_entry/sales_app_payment_entry.js
+++ b/sales_app/eactive_sales_app/doctype/sales_app_payment_entry/sales_app_payment_entry.js
@@ -1,8 +1,25 @@
 // Copyright (c) 2025, Eactive Techonologies and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Sales App Payment Entry", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on("Sales App Payment Entry", {
+	refresh(frm) {
+        frm.events.set_query(frm);
+	},
+    
+    set_query(frm) {
+        if (!frm.doc.company) return;
+        frappe.call({
+            method: "get_mode_of_payment_base_on_company_currency",
+            doc: frm.doc,
+            callback: function (r) {                
+                frm.set_query('mode_of_payment', () => {
+                    return {
+                        filters: [
+                            ['Mode of Payment', 'name', 'in', r.message]
+                        ]
+                    };
+                });
+            },
+        });        
+    }      
+});

--- a/sales_app/eactive_sales_app/doctype/sales_app_payment_entry/sales_app_payment_entry.json
+++ b/sales_app/eactive_sales_app/doctype/sales_app_payment_entry/sales_app_payment_entry.json
@@ -1,20 +1,29 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "autoname": "naming_series: naming_series",
  "creation": "2025-06-10 16:22:33.619133",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
   "section_break_vj5v",
+  "naming_series",
   "party_type",
-  "posting_date",
   "party",
   "party_name",
   "mode_of_payment",
   "paid_amount",
-  "column_break_dhth",
-  "reference_no",
   "received_amount",
+  "reference_no",
+  "column_break_dhth",
+  "company",
+  "posting_date",
+  "payment_entry_ref",
+  "proof_of_payment",
+  "proof_of_payment_view",
+  "accounting_dimensions_section",
+  "cost_center",
+  "more_information_section",
   "remarks",
   "amended_from"
  ],
@@ -32,15 +41,11 @@
    "read_only": 1
   },
   {
-   "fieldname": "posting_date",
-   "fieldtype": "Date",
-   "label": "Posting Date"
-  },
-  {
    "fieldname": "party",
    "fieldtype": "Link",
    "label": "Party",
-   "options": "Customer"
+   "options": "Customer",
+   "reqd": 1
   },
   {
    "fetch_from": "party.customer_name",
@@ -51,14 +56,15 @@
   },
   {
    "fieldname": "mode_of_payment",
-   "fieldtype": "Select",
+   "fieldtype": "Link",
    "label": "Mode Of Payment",
-   "options": "\nWire Transfer\nCash"
+   "options": "Mode of Payment"
   },
   {
    "fieldname": "paid_amount",
    "fieldtype": "Currency",
-   "label": "Paid Amount"
+   "label": "Paid Amount",
+   "no_copy": 1
   },
   {
    "fieldname": "column_break_dhth",
@@ -72,7 +78,8 @@
   {
    "fieldname": "received_amount",
    "fieldtype": "Currency",
-   "label": "Received Amount"
+   "label": "Received Amount",
+   "no_copy": 1
   },
   {
    "fieldname": "remarks",
@@ -88,16 +95,80 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Company",
+   "options": "Company",
+   "remember_last_selected_value": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "label": "Posting Date",
+   "reqd": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "accounting_dimensions_section",
+   "fieldtype": "Section Break",
+   "label": "Accounting Dimensions "
+  },
+  {
+   "fieldname": "cost_center",
+   "fieldtype": "Link",
+   "label": "Cost Center",
+   "options": "Cost Center"
+  },
+  {
+   "default": "SA-PAY-.YYYY.-",
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "options": "\nSA-PAY-.YYYY.-",
+   "reqd": 1
+  },
+  {
+   "fieldname": "payment_entry_ref",
+   "fieldtype": "Data",
+   "label": "Payment Entry Reference",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "more_information_section",
+   "fieldtype": "Section Break",
+   "label": "More Information"
+  },
+  {
+   "fieldname": "proof_of_payment",
+   "fieldtype": "Attach Image",
+   "label": "Proof of Payment",
+   "no_copy": 1,
+   "permlevel": 1
+  },
+  {
+   "depends_on": "proof_of_payment",
+   "fieldname": "proof_of_payment_view",
+   "fieldtype": "Image",
+   "no_copy": 1,
+   "options": "proof_of_payment"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-10 16:30:27.924310",
+ "modified": "2025-07-07 17:06:20.233136",
  "modified_by": "Administrator",
  "module": "Eactive Sales App",
  "name": "Sales App Payment Entry",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -111,6 +182,85 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "if_owner": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Customer",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Customer",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales Manager",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales User",
+   "share": 1
   }
  ],
  "row_format": "Dynamic",

--- a/sales_app/eactive_sales_app/doctype/sales_app_payment_entry/sales_app_payment_entry.py
+++ b/sales_app/eactive_sales_app/doctype/sales_app_payment_entry/sales_app_payment_entry.py
@@ -1,9 +1,35 @@
 # Copyright (c) 2025, Eactive Techonologies and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+
 from frappe.model.document import Document
+# from erpnext.accounts.party import get_party_account
+# from erpnext.accounts.doctype.payment_entry.payment_entry import get_account_details
 
 
 class SalesAppPaymentEntry(Document):
-	pass
+	
+	@frappe.whitelist()
+	def get_mode_of_payment_base_on_company_currency(self):
+		company_currency = frappe.db.get_value("Company", self.company, "default_currency")
+		account_with_company_currency = frappe.db.get_all("Account", 
+			filters={
+				"disabled": 0,
+				"company": self.company,
+				"account_currency": company_currency
+			},
+			pluck="name"
+		)
+		valid_mode_of_payments = []
+		if account_with_company_currency:
+			valid_mode_of_payments = frappe.db.get_all("Mode of Payment Account", 
+				filters={
+					"default_account": ["In", account_with_company_currency]
+				},
+				pluck="parent"
+			)
+		return valid_mode_of_payments
+
+	
+			

--- a/sales_app/eactive_sales_app/doctype/sales_app_payment_entry/sales_app_payment_entry.py
+++ b/sales_app/eactive_sales_app/doctype/sales_app_payment_entry/sales_app_payment_entry.py
@@ -4,12 +4,70 @@
 import frappe
 
 from frappe.model.document import Document
-# from erpnext.accounts.party import get_party_account
-# from erpnext.accounts.doctype.payment_entry.payment_entry import get_account_details
-
+from erpnext.accounts.party import get_party_account
+from erpnext.accounts.doctype.payment_entry.payment_entry import get_account_details
 
 class SalesAppPaymentEntry(Document):
+	def on_submit(self):
+		if not self.mode_of_payment:
+			frappe.throw(f"{frappe.bold('Mode of Payment')} is required.")
+
+		if not self.received_amount:
+			frappe.throw(f"{frappe.bold('Received Amount')} is required.")
+
+		# Create Payment Entry after submitted Sales Add Payment Entry
+		party_account = get_party_account(self.party_type, self.party, self.company)
+		party_account_details = get_account_details(party_account, self.posting_date)
+
+		company_account = frappe.db.get_all("Mode of Payment Account", {"company": self.company, "parent": self.mode_of_payment}, pluck="default_account")
+		
+		company_account_details = get_account_details(company_account[0], self.posting_date)
+
+		# TODO: Fetch exchange rate for multi currency
+		if party_account_details.account_currency != company_account_details.account_currency:
+			frappe.throw(f"""
+				Party Account Currency ({frappe.bold(party_account_details.account_currency)}) and 
+				Company Account Currency ({frappe.bold(company_account_details.account_currency)}) must be the same.
+			""")
+
+		pe = frappe.new_doc('Payment Entry')	
+
+		pe.docstatus = 1
+		pe.company = self.company
+		pe.posting_date = self.posting_date
+		pe.payment_type = 'Receive'
+		pe.mode_of_payment = self.mode_of_payment
+
+		pe.party_type = self.party_type
+		pe.party = self.party
+
+		pe.paid_from = party_account
+		pe.paid_from_account_currency = party_account_details.account_currency
+		pe.paid_from_account_type = party_account_details.account_type
+		pe.source_exchange_rate = 1
+
+		pe.paid_to = company_account[0]
+		pe.paid_to_account_currency = company_account_details.account_currency	
+		pe.paid_to_account_type = company_account_details.account_type
+		pe.target_exchange_rate = 1
+
+		pe.paid_amount = self.received_amount
+		pe.received_amount = self.received_amount
+		pe.reference_no = self.reference_no
+		pe.cost_center = self.cost_center
+		
+		pe.insert()
+		
+		self.db_set('payment_entry_ref', pe.name, commit=True, update_modified=False)
 	
+	def on_cancel(self):
+		pe_status =frappe.db.get_value("Payment Entry", self.payment_entry_ref, "docstatus")
+
+		if pe_status == 1:
+			pe_doc = frappe.get_doc("Payment Entry", self.payment_entry_ref)
+			pe_doc.flags.ignore_permissions = True
+			pe_doc.cancel()		
+
 	@frappe.whitelist()
 	def get_mode_of_payment_base_on_company_currency(self):
 		company_currency = frappe.db.get_value("Company", self.company, "default_currency")


### PR DESCRIPTION
Implements creation, cancellation, and validation of a Payment Entry for each corresponding Sales App Payment Entry. Ensures a one-to-one relationship and consistent synchronization between the two records.